### PR TITLE
Coherence check wrapper

### DIFF
--- a/prog/dftb+/lib_common/coherence.F90
+++ b/prog/dftb+/lib_common/coherence.F90
@@ -23,8 +23,9 @@
 
 !> Contains MPI coherence tests across a comm world
 module dftbp_coherence
-  use dftbp_accuracy, only : dp, lc
+  use dftbp_accuracy,   only : dp, lc
   use dftbp_environment
+  use dftbp_message,    only : error
 #:if WITH_MPI
   use dftbp_mpifx
 #:endif
@@ -51,13 +52,15 @@ module dftbp_coherence
   !> Check exact coherence of data across processor(s) with error handling 
   interface checkExactCoherence
 #:for _, _, NAME, DIM in EXACT_TYPES
-     module procedure coherenceWithError${NAME}$${DIM}$
+    module procedure coherenceWithError${NAME}$${DIM}$
+#:endfor     
   end interface checkExactCoherence
 
   !> Check coherence of data across processor(s) to a tolerance, with error handling  
   interface checkToleranceCoherence
 #:for _, _, NAME, DIM in APPROX_TYPES
-     module procedure approxCoherenceWithError${NAME}$${DIM}$
+    module procedure approxCoherenceWithError${NAME}$${DIM}$
+#:endfor     
   end interface checkToleranceCoherence
      
   
@@ -138,7 +141,7 @@ contains
 
   end function coherence${NAME}$${DIM}$
 #:endif
-  
+
   !> Wrapper for exact coherence with error handling
   subroutine coherenceWithError${NAME}$${DIM}$(env, data, message)
 
@@ -157,11 +160,12 @@ contains
 
     if (env%tAPICalculation) then
        if (.not. coherence${NAME}$${DIM}$(env, data)) then
-          call error("Coherence failure in "\\trim(adjustl(message))\\" across nodes")
+          call error("Coherence failure in "//trim(adjustl(message))//" across nodes")
        end if
     end if
     
   end subroutine coherenceWithError${NAME}$${DIM}$
+  
 #:endfor
 
 #:for TYPE, SHAPE, NAME, DIM in APPROX_TYPES
@@ -261,8 +265,8 @@ contains
     if (env%tAPICalculation) then             
        if (.not. approxCoherence${NAME}$${DIM}$(env, data, tol_)) then
           Write(tol_str, '(E12.5)') tol_
-          call error("Coherence failure in "\\trim(adjustl(message))\\" across nodes &
-               & for a tolerance: "\\trim(adjustl(tol_str)))
+          call error("Coherence failure in "//trim(adjustl(message))//" across nodes &
+               & for a tolerance: "//trim(adjustl(tol_str)))
        end if
     end if
     


### PR DESCRIPTION
This PR adds error-handling wrappers for exactCoherence and toleranceCoherence. Example usage:
```
call checkToleranceCoherence(env, coords0, 'coords0 in getPositions', tol=1.e-10)
! Or grouping data
allocate(coords0_and_lattice(3, nAtom+3))
coords0_and_lattice(:, 1:nAtom) = coords(:,1:nAtom)
coords0_and_lattice(:, nAtom+1: nAtom+3) = lattVec(:,1:3)
call checkExactCoherence(env, coords0_and_lattice, 'coords0 and lattice in getPositions')
```
MPI and serial implementations do not differ. message argument is required 