### PR TITLE
Fix shebang ordering

### DIFF
--- a/utils/srcmanip/set_source_headers
+++ b/utils/srcmanip/set_source_headers
@@ -98,14 +98,19 @@ def process_files(rootdir):
 
 def replace_header(fname, headerpattern, header):
     with open(fname, 'r') as fp:
-        txt = fp.read()
-    newtxt, nsub = headerpattern.subn(header, txt)
+        txt = fp.readlines()
+    first_line = txt[0]
+
+    newtxt, nsub = headerpattern.subn(header, "".join(txt))
     if nsub:
         print("{:d} substitutions in {}".format(nsub, fname))
     else:
         print("HEADER ADDED in {}".format(fname))
     if not nsub:
-        newtxt = header + '\n\n' + txt
+        if SHEBANG.match(first_line) is None:
+            newtxt = header + '\n\n' + first_line + "".join(txt[1:])
+        else:
+            newtxt = first_line + header + '\n\n' + "".join(txt[1:])
     with open(fname, 'w') as fp:
         fp.write(newtxt)
 
@@ -146,6 +151,8 @@ C_HEADER_PATTERN = re.compile(
     r'[ \t]*/\*---+\*/[ \t]*\n(?:[ \t]*/\*.*\n)*?[ \t]*/\*---+\*/[ \t]*$',
     re.MULTILINE)
 C_HEADER = pretty_header(COPYRIGHT, '/*', '*/', '-', 100)
+
+SHEBANG = re.compile(r'^#!(.*)')
 
 
 HEADER_BY_TYPE = {


### PR DESCRIPTION
Just a quick fix if a copyright header is added to a file with a shebang in the first line. I might have overlooked some edge cases, @bhourahine any remarks?